### PR TITLE
Use chip UID as USB serial number

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -35,7 +35,6 @@ THE SOFTWARE.
 #define USBD_CONFIGURATION_STRING_FS (uint8_t*) "gs_usb config"
 #define USBD_INTERFACE_STRING_FS     (uint8_t*) "gs_usb interface"
 #define DFU_INTERFACE_STRING_FS      (uint8_t*) "candleLight firmware upgrade interface"
-#define USBD_SERIALNUMBER_STRING_FS  (uint8_t*) "000000000002"
 
 #define BOARD_candleLight 1
 #define BOARD_cantact     2

--- a/include/util.h
+++ b/include/util.h
@@ -26,5 +26,8 @@ THE SOFTWARE.
 
 #pragma once
 
+#include <stdint.h>
+
 int disable_irq(void);
 void enable_irq(int primask);
+void hex32(char *out, uint32_t val);

--- a/src/usbd_desc.c
+++ b/src/usbd_desc.c
@@ -113,8 +113,15 @@ uint8_t *USBD_FS_ManufacturerStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *le
 
 uint8_t *USBD_FS_SerialStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
 {
+	char buf[25];
+
 	UNUSED(speed);
-	USBD_GetString(USBD_SERIALNUMBER_STRING_FS, USBD_StrDesc, length);
+
+	hex32(buf     , *(uint32_t*)(UID_BASE    ));
+	hex32(buf +  8, *(uint32_t*)(UID_BASE + 4));
+	hex32(buf + 16, *(uint32_t*)(UID_BASE + 8));
+
+	USBD_GetString(buf, USBD_StrDesc, length);
 	return USBD_StrDesc;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -37,3 +37,22 @@ inline void enable_irq(int primask) {
     if (primask)
         asm volatile("cpsie i\n");
 }
+
+void hex32(char *out, uint32_t val)
+{
+	char *p = out + 8;
+
+	*p-- = 0;
+
+	while (p >= out) {
+		uint8_t nybble = val & 0x0F;
+
+		if (nybble < 10)
+			*p = '0' + nybble;
+		else
+			*p = 'A' + nybble - 10;
+
+		val >>= 4;
+		p--;
+	}
+}


### PR DESCRIPTION
Instead of hardcoding the serial number in the firmware, use the
device's manufacturer-provided UID as the serial number.

This makes it easier to distinguish between multiple adaptors plugged
into the same host without having to build a separate firmware for each
one.