### PR TITLE
Feature/nucleo f072rb board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,14 @@ DEP     += $(ASM_OBJ:%.asmo=%.d)
 ELF = build/$(BOARD)/gsusb_$(BOARD).elf
 BIN = bin/gsusb_$(BOARD).bin
 
-all: candleLight cantact
+all: candleLight cantact nucleo_F072RB
 
 .PHONY : clean all
 
 clean:
 	$(MAKE) BOARD=candleLight board-clean
 	$(MAKE) BOARD=cantact board-clean
+	$(MAKE) BOARD=nucleo_F072RB board-clean
 
 candleLight:
 	$(MAKE) CHIP=STM32F042x6 BOARD=candleLight bin
@@ -53,25 +54,31 @@ cantact:
 flash-cantact:
 	$(MAKE) CHIP=STM32F072xB BOARD=cantact board-flash
 
+nucleo_F072RB:
+	$(MAKE) CHIP=STM32F072xB BOARD=nucleo_F072RB bin
+
+flash-nucleo_F072RB:
+	$(MAKE) CHIP=STM32F072xB BOARD=nucleo_F072RB board-flash
+
 board-flash: bin
 	sudo dfu-util -d 1d50:606f -a 0 -s 0x08000000 -D $(BIN)
 
 bin: $(BIN)
 
 $(BIN): $(ELF)
-	@mkdir -p $(dir $@)	
+	@mkdir -p $(dir $@)
 	$(OBJCOPY) -O binary $(ELF) $(BIN)
-	$(SIZE) --format=berkeley $(ELF) 
-	
+	$(SIZE) --format=berkeley $(ELF)
+
 $(ELF): $(OBJ) $(ASM_OBJ)
-	@mkdir -p $(dir $@)	
-	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(ASM_OBJ) 
+	@mkdir -p $(dir $@)
+	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(ASM_OBJ)
 
 -include $(DEP)
 
 build/$(BOARD)/%.o : %.c
 	@echo $<
-	@mkdir -p $(dir $@)	
+	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(INCLUDES) -MMD -c $< -o $@
 
 build/$(BOARD)/%.asmo : %.S

--- a/Makefile
+++ b/Makefile
@@ -66,19 +66,19 @@ board-flash: bin
 bin: $(BIN)
 
 $(BIN): $(ELF)
-	@mkdir -p $(dir $@)
+	@mkdir -p $(dir $@)	
 	$(OBJCOPY) -O binary $(ELF) $(BIN)
-	$(SIZE) --format=berkeley $(ELF)
-
+	$(SIZE) --format=berkeley $(ELF) 
+	
 $(ELF): $(OBJ) $(ASM_OBJ)
-	@mkdir -p $(dir $@)
-	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(ASM_OBJ)
+	@mkdir -p $(dir $@)	
+	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(ASM_OBJ) 
 
 -include $(DEP)
 
 build/$(BOARD)/%.o : %.c
 	@echo $<
-	@mkdir -p $(dir $@)
+	@mkdir -p $(dir $@)	
 	$(CC) $(CFLAGS) $(INCLUDES) -MMD -c $< -o $@
 
 build/$(BOARD)/%.asmo : %.S

--- a/include/config.h
+++ b/include/config.h
@@ -36,8 +36,9 @@ THE SOFTWARE.
 #define USBD_INTERFACE_STRING_FS     (uint8_t*) "gs_usb interface"
 #define DFU_INTERFACE_STRING_FS      (uint8_t*) "candleLight firmware upgrade interface"
 
-#define BOARD_candleLight 1
-#define BOARD_cantact     2
+#define BOARD_candleLight 	1
+#define BOARD_cantact     	2
+#define BOARD_nucleo_F072RB 3
 
 #if BOARD == BOARD_candleLight
 	#define USBD_PRODUCT_STRING_FS (uint8_t*) "candleLight USB to CAN adapter"
@@ -66,6 +67,19 @@ THE SOFTWARE.
 
 	#define LED2_GPIO_Port GPIOB
 	#define LED2_Pin GPIO_PIN_1
+	#define LED2_Mode GPIO_MODE_OUTPUT_PP
+
+#elif BOARD == BOARD_nucleo_F072RB
+	#define USBD_MANUFACTURER_STRING    (uint8_t*) "ST"
+	#define USBD_PRODUCT_STRING_FS 		(uint8_t*) "NUCLEO-F072RB gs_usb"
+	// SILENT pin not connected
+
+	#define LED1_GPIO_Port GPIOA
+	#define LED1_Pin GPIO_PIN_5
+	#define LED1_Mode GPIO_MODE_OUTPUT_PP
+
+	#define LED2_GPIO_Port GPIOA
+	#define LED2_Pin GPIO_PIN_6
 	#define LED2_Mode GPIO_MODE_OUTPUT_PP
 
 #else

--- a/include/config.h
+++ b/include/config.h
@@ -35,13 +35,13 @@ THE SOFTWARE.
 #define USBD_INTERFACE_STRING_FS     (uint8_t*) "gs_usb interface"
 #define DFU_INTERFACE_STRING_FS      (uint8_t*) "candleLight firmware upgrade interface"
 
-#define BOARD_candleLight   1
-#define BOARD_cantact       2
-#define BOARD_nucleo_F072RB 3
+#define BOARD_candleLight	1
+#define BOARD_cantact		2
+#define BOARD_nucleo_F072RB	3
 
 #if BOARD == BOARD_candleLight
-    #define USBD_MANUFACTURER_STRING   (uint8_t*) "bytewerk"
-	#define USBD_PRODUCT_STRING_FS     (uint8_t*) "candleLight USB to CAN adapter"
+	#define USBD_MANUFACTURER_STRING	(uint8_t*) "bytewerk"
+	#define USBD_PRODUCT_STRING_FS		(uint8_t*) "candleLight USB to CAN adapter"
 
 	#define CAN_S_Pin GPIO_PIN_13
 	#define CAN_S_GPIO_Port GPIOC
@@ -57,8 +57,8 @@ THE SOFTWARE.
 	#define LED2_Active_Low
 
 #elif BOARD == BOARD_cantact
-    #define USBD_MANUFACTURER_STRING   (uint8_t*) "bytewerk"
-	#define USBD_PRODUCT_STRING_FS     (uint8_t*) "cantact gs_usb"
+	#define USBD_MANUFACTURER_STRING	(uint8_t*) "bytewerk"
+	#define USBD_PRODUCT_STRING_FS		(uint8_t*) "cantact gs_usb"
 
 	// SILENT pin not connected
 
@@ -71,8 +71,8 @@ THE SOFTWARE.
 	#define LED2_Mode GPIO_MODE_OUTPUT_PP
 
 #elif BOARD == BOARD_nucleo_F072RB
-	#define USBD_MANUFACTURER_STRING   (uint8_t*) "ST"
-	#define USBD_PRODUCT_STRING_FS     (uint8_t*) "NUCLEO-F072RB gs_usb"
+	#define USBD_MANUFACTURER_STRING	(uint8_t*) "ST"
+	#define USBD_PRODUCT_STRING_FS		(uint8_t*) "NUCLEO-F072RB gs_usb"
 	// SILENT pin not connected
 
 	#define LED1_GPIO_Port GPIOA

--- a/include/config.h
+++ b/include/config.h
@@ -31,17 +31,17 @@ THE SOFTWARE.
 #define USBD_VID                     0x1d50
 #define USBD_PID_FS                  0x606f
 #define USBD_LANGID_STRING           1033
-#define USBD_MANUFACTURER_STRING     (uint8_t*) "bytewerk"
 #define USBD_CONFIGURATION_STRING_FS (uint8_t*) "gs_usb config"
 #define USBD_INTERFACE_STRING_FS     (uint8_t*) "gs_usb interface"
 #define DFU_INTERFACE_STRING_FS      (uint8_t*) "candleLight firmware upgrade interface"
 
-#define BOARD_candleLight 	1
-#define BOARD_cantact     	2
+#define BOARD_candleLight   1
+#define BOARD_cantact       2
 #define BOARD_nucleo_F072RB 3
 
 #if BOARD == BOARD_candleLight
-	#define USBD_PRODUCT_STRING_FS (uint8_t*) "candleLight USB to CAN adapter"
+    #define USBD_MANUFACTURER_STRING   (uint8_t*) "bytewerk"
+	#define USBD_PRODUCT_STRING_FS     (uint8_t*) "candleLight USB to CAN adapter"
 
 	#define CAN_S_Pin GPIO_PIN_13
 	#define CAN_S_GPIO_Port GPIOC
@@ -57,7 +57,8 @@ THE SOFTWARE.
 	#define LED2_Active_Low
 
 #elif BOARD == BOARD_cantact
-	#define USBD_PRODUCT_STRING_FS (uint8_t*) "cantact gs_usb"
+    #define USBD_MANUFACTURER_STRING   (uint8_t*) "bytewerk"
+	#define USBD_PRODUCT_STRING_FS     (uint8_t*) "cantact gs_usb"
 
 	// SILENT pin not connected
 
@@ -70,8 +71,8 @@ THE SOFTWARE.
 	#define LED2_Mode GPIO_MODE_OUTPUT_PP
 
 #elif BOARD == BOARD_nucleo_F072RB
-	#define USBD_MANUFACTURER_STRING    (uint8_t*) "ST"
-	#define USBD_PRODUCT_STRING_FS 		(uint8_t*) "NUCLEO-F072RB gs_usb"
+	#define USBD_MANUFACTURER_STRING   (uint8_t*) "ST"
+	#define USBD_PRODUCT_STRING_FS     (uint8_t*) "NUCLEO-F072RB gs_usb"
 	// SILENT pin not connected
 
 	#define LED1_GPIO_Port GPIOA

--- a/src/usbd_desc.c
+++ b/src/usbd_desc.c
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 #include "usbd_core.h"
 #include "usbd_desc.h"
+#include "util.h"
 #include "config.h"
 
 uint8_t *USBD_FS_DeviceDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
@@ -113,15 +114,15 @@ uint8_t *USBD_FS_ManufacturerStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *le
 
 uint8_t *USBD_FS_SerialStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
 {
-	char buf[25];
-
 	UNUSED(speed);
+
+	char buf[25];
 
 	hex32(buf     , *(uint32_t*)(UID_BASE    ));
 	hex32(buf +  8, *(uint32_t*)(UID_BASE + 4));
 	hex32(buf + 16, *(uint32_t*)(UID_BASE + 8));
 
-	USBD_GetString(buf, USBD_StrDesc, length);
+	USBD_GetString((uint8_t*)buf, USBD_StrDesc, length);
 	return USBD_StrDesc;
 }
 


### PR DESCRIPTION
This adds the [Nucleo F072RB](https://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-eval-tools/stm32-mcu-eval-tools/stm32-mcu-nucleo/nucleo-f072rb.html) as a target in Makefile and config.h
Also adds the possibility to give each board a different USBD_MANUFACTURER_STRING.